### PR TITLE
Fix NATO link

### DIFF
--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@
 
 ### Papers
 
-- [NATO 68 & 69 Software Engineering Conference Proceedings](homepages.cs.ncl.ac.uk/brian.randell/NATO/)
+- [NATO 68 & 69 Software Engineering Conference Proceedings](http://homepages.cs.ncl.ac.uk/brian.randell/NATO/)
 - [Managing the Development of Large Software Systems](http://www.cs.umd.edu/class/spring2003/cmsc838p/Process/waterfall.pdf)
 - [EWD Archives](http://www.cs.utexas.edu/~EWD/) (Dijkstra's blog, basically)
 


### PR DESCRIPTION
NATO link is broken, it misses _http://_ prefix.