### PR TITLE
Added "Programmers Handbook for Mark II"

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,6 +28,7 @@
 - [NATO 68 & 69 Software Engineering Conference Proceedings](http://homepages.cs.ncl.ac.uk/brian.randell/NATO/)
 - [Managing the Development of Large Software Systems](http://www.cs.umd.edu/class/spring2003/cmsc838p/Process/waterfall.pdf)
 - [EWD Archives](http://www.cs.utexas.edu/~EWD/) (Dijkstra's blog, basically)
+- [Programmers Handbook for Manchester Electronic Computer Mark II](http://www.alanturing.net/turing_archive/archive/m/m01/M01-001.html) ([PDF transcription](http://curation.cs.manchester.ac.uk/computer50/www.computer50.org/kgill/mark1/RobertTau/turing.pdf))
 
 ### Other
 


### PR DESCRIPTION
Maybe one of the earliest programming handbook. Written by Alan Turing in 1951.